### PR TITLE
Bump BOOM and fix Verilator failing on CMPCONST warning

### DIFF
--- a/verisim/Makefrag-verilator
+++ b/verisim/Makefrag-verilator
@@ -30,6 +30,6 @@ VERILATOR_FLAGS := --top-module $(MODEL) \
   +define+PRINTF_COND=\$$c\(\"verbose\",\"\&\&\"\,\"done_reset\"\) \
   +define+STOP_COND=\$$c\(\"done_reset\"\) --assert \
   --output-split 20000 \
-	-Wno-STMTDLY --x-assign unique \
+	-Wno-STMTDLY -Wno-CMPCONST --x-assign unique \
   -I$(base_dir)/testchipip/vsrc -I$(base_dir)/rocket-chip/src/main/resources/vsrc \
   -O3 -CFLAGS "$(CXXFLAGS) -DVERILATOR -DTEST_HARNESS=V$(MODEL) -include $(base_dir)/rocket-chip/src/main/resources/csrc/verilator.h -include $(build_dir)/$(PROJECT).$(MODEL).$(CONFIG).plusArgs"


### PR DESCRIPTION
Bump BOOM to most recent commit (includes changes to fix multiple small bugs, clean up code, and re-enable PMPs)

Additionally, has a commit to ignore CMPCONST warnings in Verilator builds that were caused by the new BOOM changes. This would prevent the normal BoomConfig from compiling with Verilator.