### PR TITLE
Added verilator_install to makefile

### DIFF
--- a/verisim/Makefrag-verilator
+++ b/verisim/Makefrag-verilator
@@ -2,6 +2,9 @@
 VERILATOR_VERSION=3.904
 VERILATOR_SRCDIR=verilator/src/verilator-$(VERILATOR_VERSION)
 INSTALLED_VERILATOR=$(abspath verilator/install/bin/verilator)
+
+verilator_install: $(INSTALLED_VERILATOR)
+
 $(INSTALLED_VERILATOR): $(VERILATOR_SRCDIR)/bin/verilator
 	$(MAKE) -C $(VERILATOR_SRCDIR) installbin installdata
 	touch $@


### PR DESCRIPTION
For installing verilator separately from building a config. This is used during CircleCI to speed up the build process.