### PR TITLE
[TOOLS] Update verilator to 4.008

### DIFF
--- a/verisim/Makefrag-verilator
+++ b/verisim/Makefrag-verilator
@@ -1,5 +1,5 @@
-# Build and install our own Verilator, to work around versionining issues.
-VERILATOR_VERSION=3.904
+# Build and install our own Verilator, to work around versioning issues.
+VERILATOR_VERSION=4.008
 VERILATOR_SRCDIR=verilator/src/verilator-$(VERILATOR_VERSION)
 INSTALLED_VERILATOR=$(abspath verilator/install/bin/verilator)
 
@@ -33,6 +33,7 @@ VERILATOR_FLAGS := --top-module $(MODEL) \
   +define+PRINTF_COND=\$$c\(\"verbose\",\"\&\&\"\,\"done_reset\"\) \
   +define+STOP_COND=\$$c\(\"done_reset\"\) --assert \
   --output-split 20000 \
-	-Wno-STMTDLY -Wno-CMPCONST --x-assign unique \
+  --no-threads \
+  -Wno-STMTDLY -Wno-CMPCONST --x-assign unique \
   -I$(base_dir)/testchipip/vsrc -I$(base_dir)/rocket-chip/src/main/resources/vsrc \
   -O3 -CFLAGS "$(CXXFLAGS) -DVERILATOR -DTEST_HARNESS=V$(MODEL) -include $(base_dir)/rocket-chip/src/main/resources/csrc/verilator.h -include $(build_dir)/$(PROJECT).$(MODEL).$(CONFIG).plusArgs"


### PR DESCRIPTION
Updated Verilator to 4.008 **without multithreading**. Unfortunately, multithreading breaks the normal tests currently. A future update should be to enable this.

Note: This was tested with the CI integration in riscv-boom.