### PR TITLE
Removed Makefrag.pkgs from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-/Makefrag.pkgs
 target
 *.jar
 *.stamp


### PR DESCRIPTION
In addition to https://github.com/riscv-boom/boom-template/pull/15