### PR TITLE
Wno-CMPCONST is no longer needed

### DIFF
--- a/verisim/Makefrag-verilator
+++ b/verisim/Makefrag-verilator
@@ -40,6 +40,6 @@ VERILATOR_FLAGS := --top-module $(MODEL) \
   +define+STOP_COND=\$$c\(\"done_reset\"\) --assert \
   --output-split 20000 \
   --no-threads \
-  -Wno-STMTDLY -Wno-CMPCONST --x-assign unique \
+  -Wno-STMTDLY --x-assign unique \
   -I$(base_dir)/testchipip/vsrc -I$(base_dir)/rocket-chip/src/main/resources/vsrc \
   -O3 -CFLAGS "$(CXXFLAGS) -DVERILATOR -DTEST_HARNESS=V$(MODEL) -include $(base_dir)/rocket-chip/src/main/resources/csrc/verilator.h -include $(build_dir)/$(PROJECT).$(MODEL).$(CONFIG).plusArgs"


### PR DESCRIPTION
Wno-CMPCONST is no longer needed with the new FIRRTL
see https://github.com/freechipsproject/firrtl/issues/990